### PR TITLE
Ignore packages outside of texmf directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,5 @@ _minted-*
 /unversioned/
 
 # derivative files generated via .ins and .dtx
-/beamer/themes/color/falcon/beamercolorthemefalcon.sty
-/beamer/themes/theme/usafa.edu/beamerthemeusafa.edu.sty
-/beamer/themes/theme/usafa.edu/usafa.eps
+*.cls
+*.sty

--- a/beamer/themes/theme/usafa.edu/.gitignore
+++ b/beamer/themes/theme/usafa.edu/.gitignore
@@ -1,0 +1,1 @@
+usafa.eps

--- a/texmf/.gitignore
+++ b/texmf/.gitignore
@@ -1,0 +1,3 @@
+# include classes and package in this directory
+!*.cls
+!*.sty


### PR DESCRIPTION
This change modifies the .gitignore files to exclude all classes and
packages (i.e., *.cls and *.sty files) outside of the textmf
directory. It eliminates the need to ignore these files individually.