### PR TITLE
Add dependency on reference.bib

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -40,7 +40,7 @@ while ( grep -q '^LaTeX Warning: Label(s) may have changed' $*.log ) do \
 done
 endef
 
-DEPENDENCIES = $(wildcard *.cls) $(wildcard *.sty) \
+DEPENDENCIES = $(wildcard *.bib) $(wildcard *.cls) $(wildcard *.sty) \
                $(wildcard $(CWD)glossary.tex) $(wildcard $(CWD)references.bib)
 
 %.pdf: %.dtx $(DEPENDENCIES) .version.tex


### PR DESCRIPTION
This change adds a dependency for LaTeX documents on reference.bib in
the same directory as the document.