### PR TITLE
Add CI job to check for misspelled words

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,3 +19,31 @@ jobs:
             for package in $(find . -name Makefile); do
               make --directory="$(dirname "$package")";
             done
+
+  spelling:
+    docker:
+      - image: circleci/golang
+
+    resource_class: small
+
+    steps:
+      - checkout
+
+      - run:
+          name: install
+          working_directory: /usr/local/
+          command: |
+            curl -L https://git.io/misspell | sudo bash
+
+      - run:
+          name: misspell
+          command: |
+            misspell --error \
+                $(git diff-tree --no-commit-id --name-only -r HEAD)
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build
+      - spelling


### PR DESCRIPTION
Spell checking is challenging given the number of technical terms,
names, and code snippets. Rather than trying to maintain an extensive
white list, this change uses the misspell utility to check for
commonly misspelled words.

misspell: https://github.com/client9/misspell