### PR TITLE
Use Debian Buster as base image for CI build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ jobs:
           name: install dependencies
           command: |
             apt update && apt install --no-install-recommends --yes \
-                    $(cat .circleci/dependencies.list)
+                    $(cat .circleci/dependencies/apt.list)
+            pip install --requirement .circleci/dependencies/python.list
 
       - run:
           name: build packages

--- a/.circleci/dependencies/apt.list
+++ b/.circleci/dependencies/apt.list
@@ -1,5 +1,5 @@
 ghostscript
 git
-python-pygments
+python-pip
 texlive-font-utils
 texlive-generic-extra

--- a/.circleci/dependencies/python.list
+++ b/.circleci/dependencies/python.list
@@ -1,0 +1,1 @@
+pygments


### PR DESCRIPTION
Updating the base image is required to access more recent versions of
LaTeX packages (TeX Live 2018).