### PR TITLE
Add action for `git diff --check`

### DIFF
--- a/.github/workflows/git-diff-check.yaml
+++ b/.github/workflows/git-diff-check.yaml
@@ -1,0 +1,19 @@
+name: git diff --check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  git-diff--check:
+    name: git diff --check
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: git diff --check
+        uses: joel-coffman/action-git-diff-check@0.1.1


### PR DESCRIPTION
This action checks changes for conflict markers and whitespace errors.
It prevents mistakes such as the accidental inclusion of a conflict
marker after resolving merge conflicts.