### PR TITLE
Remove relative paths in Makefiles

### DIFF
--- a/beamer/themes/color/falcon/Makefile
+++ b/beamer/themes/color/falcon/Makefile
@@ -8,4 +8,4 @@ beamercolorthemefalcon.pdf: beamercolorthemefalcon.sty example.pdf
 
 example.pdf: beamercolorthemefalcon.sty
 
-include ../../../../Makefile.mk
+include $(shell git rev-parse --show-toplevel)/Makefile.mk

--- a/beamer/themes/theme/usafa.edu/Makefile
+++ b/beamer/themes/theme/usafa.edu/Makefile
@@ -9,7 +9,7 @@ beamerthemeusafa.edu.sty: | beamercolorthemefalcon.sty
 
 example.pdf: beamerthemeusafa.edu.sty
 
-include ../../../../Makefile.mk
+include $(shell git rev-parse --show-toplevel)/Makefile.mk
 
 # fall-back for Beamer themes
 beamercolorthemefalcon.sty:

--- a/graded-review/Makefile
+++ b/graded-review/Makefile
@@ -7,4 +7,4 @@ minted:
 graded-review.sty:
 graded-review.pdf: graded-review.sty | minted
 
-include ../Makefile.mk
+include $(shell git rev-parse --show-toplevel)/Makefile.mk


### PR DESCRIPTION
This change removes the relative path to Makefile.mk at the root of
the repository with a shell command that determines the repository
root automatically. With this change, a Makefile can be copied to any
directory in the repository without the need to modify the relative
path.