### PR TITLE
Add ability to ignore misspelled words

### DIFF
--- a/.ci/spelling/check.sh
+++ b/.ci/spelling/check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -u
+
+
+files="$(git diff-tree --no-commit-id --name-only -r HEAD)"
+if [ 0 -lt $# ]; then
+  files=$@
+fi
+
+
+args="."
+
+ignores=( $(find . -name .misspellignore) )
+if [ ${#ignores[@]} -gt 0 ]; then
+  args="--invert-match $(for file in $ignores; do echo "--file=$file"; done)"
+fi
+
+
+! misspell --error $files | grep $args | grep --invert-match .misspellignore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,7 @@ jobs:
       - run:
           name: misspell
           command: |
-            misspell --error \
-                $(git diff-tree --no-commit-id --name-only -r HEAD)
+            .ci/spelling/check.sh
 
 workflows:
   version: 2


### PR DESCRIPTION
In the case of an "intentional" misspelling (e.g., reproducing a quote
with a misspelled word), the relevant output from `misspell` should be
added to a file named .misspellignore. Such entries are ignored and
not considered to be mistakes.