### PR TITLE
Install Git and OpenSSH on Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,14 @@ jobs:
       - image: sunslayer/latex-docker:buster
 
     steps:
+      # ensure that Git is installed
+      - run:
+          name: install Git
+          command: |
+            apt update && apt install --no-install-recommends --yes \
+                    git \
+                    openssh-client
+
       - checkout
 
       - run:


### PR DESCRIPTION
If Git isn't installed on the base image, CircleCI attempts to use its
native Git client, but warns that the behavior may differ from an
official Git distribution.

It appears that one of the differences between CircleCI's native
client and the official Git client is that the native client does not
check out files that are ignored. For example, `git status` reports
the following after the checkout step on a development branch:

    Not currently on any branch.
    Changes not staged for commit:
      (use "git add/rm <file>..." to update what will be committed)
      (use "git checkout -- <file>..." to discard changes in working
              directory)

	    deleted:    promotion/template/application.sty

    no changes added to commit (use "git add" and/or "git commit -a")

because *.sty files are ignored in the repository by default. Using
the official client does not have the same issue with "missing" files.
Moreover, the behavior of CircleCI's native client appears to have
changed within the past two days, as the build job previously did not
fail due to missing the aforementioned file.

This change modifies the job steps so that Git and the OpenSSH client
are installed before checking out the code. As a side effect, the job
can now be executed using CircleCI's local CLI.