### PR TITLE
Force table of contents entry to be a PDF string

### DIFF
--- a/promotion/supplements.dtx
+++ b/promotion/supplements.dtx
@@ -279,6 +279,14 @@
     }%
     \pgfkeys{supplement,##1}%
 %    \end{macrocode}
+% Extract the string of the table of contents entry to avoid errors when the title contains formatting (e.g., a different font).
+%     \changes{0.1.1}{2020/11/16}{%
+%       Force table of contents entry to be a string
+%     }
+%    \begin{macrocode}
+    \pdfstringdef{\supplements@supplement@tocentry}%
+        {\supplements@supplement@tocentry}%
+%    \end{macrocode}
 % Store the arguments.
 %    \begin{macrocode}
     \edef\supplements@supplement@path{\supplements@directory/##2}%


### PR DESCRIPTION
This change allows the title of supplements to contain formatting
(e.g., formatting such as emphasis) by only including the text in the
table of contents entry.