### PR TITLE
Do not convert title to PDF string for TOC

### DIFF
--- a/promotion/supplements.dtx
+++ b/promotion/supplements.dtx
@@ -280,14 +280,6 @@
     }%
     \pgfkeys{supplement,##1}%
 %    \end{macrocode}
-% Extract the string of the table of contents entry to avoid errors when the title contains formatting (e.g., a different font).
-%     \changes{0.1.1}{2020/11/16}{%
-%       Force table of contents entry to be a string
-%     }
-%    \begin{macrocode}
-    \pdfstringdef{\supplements@supplement@tocentry}%
-        {\supplements@supplement@tocentry}%
-%    \end{macrocode}
 % Store the arguments.
 %    \begin{macrocode}
     \def\supplements@supplement@path{\supplements@directory/##2}%

--- a/promotion/template/application.tex
+++ b/promotion/template/application.tex
@@ -107,6 +107,7 @@ I believe no special accounting of emphasis is necessary, and there are no omiss
     type=\LaTeXe{} packages,
 ]
   \supplement[
+      tocentry={The promotion package},
   ]{promotion/promotion.pdf}{The \textsf{promotion} package}
 \end{supplements}
 


### PR DESCRIPTION
Invoking \pdfstringdef (from the hyperref package) to convert the
supplement title to a plain text string for the table of contents
(TOC) has unintended side effects, such as the removal of parentheses.
This change removes that code, which forces the user to specify the
table of contents entry manually when the title is not plain text.