### PR TITLE
Create CTAN distribution archives for packages

### DIFF
--- a/.ci/build/make/dependencies/apt.list
+++ b/.ci/build/make/dependencies/apt.list
@@ -9,3 +9,4 @@ texlive-font-utils
 texlive-fonts-extra
 texlive-generic-extra
 texlive-latex-extra
+zip

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ _minted-*
 # derivative files generated via .ins and .dtx
 *.cls
 *.sty
+
+# package distribution archive
+*.zip

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ default: $(packages) promotion/template
 
 .PHONY: $(packages)
 $(packages):
-	$(MAKE) -C $@
+	$(MAKE) -C $@ dist
 
 .PHONY: promotion/template
 promotion/template: | promotion

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -70,6 +70,25 @@ veryclean: clean
 force: veryclean default
 
 
+package = \
+        $(wildcard *.dtx) \
+        $(wildcard *.ins) \
+        $(patsubst %.dtx,%.pdf,$(wildcard *.dtx)) \
+        $(wildcard README)
+
+archive = $(patsubst %.dtx,%.zip,$(wildcard *.dtx))
+# multiple packages (i.e., bundle) => use the directory as the package name
+ifneq ($(words $(package_name)),1)
+archive = $(notdir $(CURDIR)).zip
+endif
+
+$(archive): $(package)
+	zip $(archive) $(package)
+
+.PHONY: dist
+dist: $(archive)
+
+
 %:: %.url
 	[ -f $@ ] || curl --location --output $@ $$(cat $<)
 


### PR DESCRIPTION
This change creates a distribution archive for each package when
`make` is executed in the root directory of the repository. The
distribution archive for each packages comprises its documented LaTeX
(.dtx), installer (.ins), and documentation.

CTAN instructions: https://ctan.org/help/upload-pkg