### PR TITLE
Place package inside directory for distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ default: $(packages) promotion/template
 
 .PHONY: $(packages)
 $(packages):
-	$(MAKE) -C $@ dist
+	$(MAKE) -C $@ dist distcheck
 
 .PHONY: promotion/template
 promotion/template: | promotion

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -82,11 +82,32 @@ ifneq ($(words $(package_name)),1)
 archive = $(notdir $(CURDIR)).zip
 endif
 
+# target-specific variables
+%.zip: directory := $(shell mktemp --directory)
+%.zip: package_name = $(basename $@)
+
 %.zip: $(package)
-	zip $(archive) $(package)
+	mkdir $(directory)/$(package_name)
+	cp $(package) $(directory)/$(package_name)
+	cd $(directory) && zip -r $@ $(package_name)
+	mv $(directory)/$@ $@
+	$(RM) --recursive $(directory)
 
 .PHONY: dist
 dist: $(archive)
+
+.PHONY: distcheck
+distcheck: dist
+	unzip -l $(archive) | grep '$(basename $(archive))/$$'  # package directory
+	unzip -l $(archive) | grep '\.dtx$$'  # documented LaTeX (source)
+	unzip -l $(archive) | grep '\.ins$$'  # installer
+	unzip -l $(archive) | grep '\.pdf$$'  # documentation
+
+_dist_derivatives += $(archive)
+
+.PHONY: distclean
+distclean:
+	$(RM) $(_dist_derivatives)
 
 
 %:: %.url

--- a/promotion/template/Makefile
+++ b/promotion/template/Makefile
@@ -89,6 +89,4 @@ distcheck: dist
 # target-specific variables
 distcheck: directory := $(shell mktemp --directory)
 
-.PHONY: distclean
-distclean:
-	$(RM) --recursive $(archive) $(distribution)
+_dist_derivatives += $(distribution)


### PR DESCRIPTION
For distribution, CTAN prescribes the structure of packages. In
particular, all files should be inside a directory that is inside a
ZIP archive. That is, the contents of the distribution archive should
be as follows:

    my-package.zip:
      my-package/
        README
        my-package.dtx
        my-package.ins
        my-package.pdf

This change follows that recommendation instead of having all the
files in the root of the distribution archive (i.e., no internal
directory structure).

CTAN instructions: https://ctan.org/help/upload-pkg