### PR TITLE
Add prerequisite on package to documentation

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -45,7 +45,7 @@ DEPENDENCIES = $(wildcard *.bib) $(wildcard $(CWD)references.bib) \
 
 PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
 
-%.pdf: %.dtx $(DEPENDENCIES) .version.tex
+%.pdf: %.dtx %.sty $(DEPENDENCIES) .version.tex
 	$(compile-doc)
 
 %.pdf: %.tex $(DEPENDENCIES) $(PACKAGES) \


### PR DESCRIPTION
This change adds a missing prerequisite on the package (e.g., *.sty
file) to the documentation for that package.

Previously, the Makefile for each package listed the package and its
documentation in the default targets, which masked this issue because
the package was always built prior to the documentation, but building
the documentation by itself could fail due to the missing
prerequisite.