### PR TITLE
Use consistent rule for building packages

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -54,8 +54,16 @@ PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
        $(shell find . -mindepth 2 -name "*.tex")
 	$(compile-doc)
 
+%.sty: directory = $(dir $<)
 %.sty: %.ins %.dtx
-	$(TEX) -draftmode $<
+	$(TEX) -draftmode -output-directory=$(directory) $<
+
+# include packages in the search path
+packages != $(MAKE) --directory=$(CWD) --quiet list 2> /dev/null
+
+vpath %.ins $(CWD):$(addprefix $(CWD)/,$(packages))
+vpath %.dtx $(CWD):$(addprefix $(CWD)/,$(packages))
+vpath %.sty $(CWD):$(addprefix $(CWD)/,$(packages))
 
 
 derivatives += *.acn *.acr *.alg *.aux *.bbl *.blg *.dvi *.glb *.glx *.glg *.glo *.gls *.idx *.ind *.ilg *.ist *.log *.lof *.lot *.nav *.out *.pyg *.snm *.toc *.vrb

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -59,7 +59,9 @@ PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
 	$(TEX) -draftmode -output-directory=$(directory) $<
 
 # include packages in the search path
+ifneq ($(CWD),.)  # ...but not if it will cause infinite recursion
 packages != $(MAKE) --directory=$(CWD) --quiet list 2> /dev/null
+endif
 
 vpath %.ins $(CWD):$(addprefix $(CWD)/,$(packages))
 vpath %.dtx $(CWD):$(addprefix $(CWD)/,$(packages))

--- a/beamer/themes/theme/usafa.edu/Makefile
+++ b/beamer/themes/theme/usafa.edu/Makefile
@@ -4,13 +4,9 @@ default: beamerthemeusafa.edu.sty example.pdf beamerthemeusafa.edu.pdf
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-beamerthemeusafa.edu.pdf: beamerthemeusafa.edu.sty example.pdf | minted
-beamerthemeusafa.edu.sty: | beamercolorthemefalcon.sty
+beamerthemeusafa.edu.pdf: beamercolorthemefalcon.sty beamerthemeusafa.edu.sty example.pdf | minted
+beamerthemeusafa.edu.sty:
 
 example.pdf: beamerthemeusafa.edu.sty
 
 include $(shell git rev-parse --show-toplevel)/Makefile.mk
-
-# fall-back for Beamer themes
-beamercolorthemefalcon.sty:
-	$(MAKE) --directory=../../color/falcon $@

--- a/promotion/Makefile
+++ b/promotion/Makefile
@@ -10,7 +10,7 @@ documentation: $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-promotion.pdf: promotion.sty | minted
+promotion.pdf: promotion.sty record.sty statement.sty supplements.sty | minted
 record.pdf: record.sty | minted
 statement.pdf: statement.sty | minted
 supplements.pdf: supplements.sty | minted record.pdf statement.pdf


### PR DESCRIPTION
This change removes the order-only prerequisites used to build other
packages (in this repository) in favor of "normal" prerequisites.