### PR TITLE
Revert "Follow official template for motto in foot line"

### DIFF
--- a/beamer/themes/theme/usafa.edu/beamerthemeusafa.edu.dtx
+++ b/beamer/themes/theme/usafa.edu/beamerthemeusafa.edu.dtx
@@ -141,12 +141,6 @@
 % Trebuchet~MS is used in the official template.
 % Fira Sans is a similar humanist sans-serif typeface that is distributed with \LaTeX.
 %
-% Require the \textsf{microtype} package to adjust tracking (i.e., letter spacing).
-%    \begin{macrocode}
-\RequirePackage{microtype}
-%    \end{macrocode}
-%
-%
 % Require the \textsf{pgfopts} package to parse package options.
 %    \begin{macrocode}
 \RequirePackage{pgfopts}
@@ -251,50 +245,23 @@
 % \end{macro}
 %
 % Define the footline template.
-%
-% Define the color and font style for the motto.
 %    \begin{macrocode}
-\setbeamercolor{motto in foot}{%
-  fg=Falcon 2000 Alternate Silver,
-}
-\setbeamerfont{motto in foot}{%
-  size=\scriptsize,
-  shape=\slshape,
-  series=\bfseries,
-}
-%    \end{macrocode}
-% Define the content of the ``motto in foot'' template.
-% \mintinline{latex}{\textls} adjusts the tracking (i.e., letter spacing) of its text based on the value of its optional argument (in thousands of an \texttt{em}).
-% Quoting from \textsf{microtype}'s documentation,
-% \begin{quote}
-%   \dots letterspacing lowercase text is held in abhorrence by honourable typographers.
-%   Unless you know what you are doing, you should probably only letterspace capitals or small capitals.
-% \end{quote}
-% Alas, this style reproduces that of the official presentation template (albeit not using spaces between each individual letter as the template does).
-%    \begin{macrocode}
-\setbeamertemplate{motto in foot}
-{
-  \strut
-  \textls[400]{%
-    Integrity $\boldsymbol{\strut\cdot}$
-    Service $\boldsymbol{\cdot}$
-    Excellence
-  }
-}
-
 \defbeamertemplate{footline}{usafa.edu}{%
   \leavevmode%
   \hbox{%
     \begin{beamercolorbox}[
-        dp=1.25ex,%
+        dp=1.125ex,%
+        ht=2.5ex,%
         leftskip=1em,%
         rightskip=1em,%
         wd=\paperwidth,%
     ]{palette quaternary}%
-      \hfil\rule{\paperwidth - 3em}{1pt}\hfil\par%
-      \vspace{0.2\baselineskip}%
+      \hfil\rule{\paperwidth - 7em}{0.5pt}\hfil\par%
       \hfill%
-      \usebeamertemplate***{motto in foot}%
+      \smash{%
+        \usebeamerfont{page number in head/foot}%
+        Integrity $\boldsymbol{\cdot}$ Service $\boldsymbol{\cdot}$ Excellence%
+      }%
       \hfill%
       \llap{%
         \usebeamerfont{page number in head/foot}%


### PR DESCRIPTION
This partially reverts commit d8e916d82cc4864effa6c1862d6b9a277534b267
which unintentionally modified the footline of the usafa.edu Beamer
theme.