### PR TITLE
promotion: Guard use of amssymb package

### DIFF
--- a/promotion/record.dtx
+++ b/promotion/record.dtx
@@ -390,7 +390,7 @@
 % \subsection{Packages}
 % Load packages required by this one.
 %    \begin{macrocode}
-\@ifpackageloaded{newtxmath}{}{% https://tex.stackexchange.com/q/564075#comment-1421648
+\@ifpackageloaded{newtxmath}{}{% https://tex.stackexchange.com/q/564075
   \RequirePackage{amssymb}
 }
 \RequirePackage{bibentry}

--- a/promotion/record.dtx
+++ b/promotion/record.dtx
@@ -381,8 +381,8 @@
 % Identify package and version.
 %    \begin{macrocode}
 \ProvidesPackage{record}[%
-    2020/10/09 %
-    v0.1.0 %
+    2023/01/13 %
+    v0.1.1 %
     Package for scholarship and service records%
 ]
 %    \end{macrocode}
@@ -408,6 +408,9 @@
 
 \RequirePackage{hyperfix}
 %    \end{macrocode}
+% \changes{0.1.1}{2023/01/13}{
+%   Do not use amssymb if newtxmath loaded
+% }
 %
 % \subsection{Options}
 % Define the package options.

--- a/promotion/record.dtx
+++ b/promotion/record.dtx
@@ -390,7 +390,9 @@
 % \subsection{Packages}
 % Load packages required by this one.
 %    \begin{macrocode}
-\RequirePackage{amssymb}
+\@ifpackageloaded{newtxmath}{}{% https://tex.stackexchange.com/q/564075#comment-1421648
+  \RequirePackage{amssymb}
+}
 \RequirePackage{bibentry}
 \RequirePackage{booktabs}
 \RequirePackage{enumitem}[2018-11-30]


### PR DESCRIPTION
The amssymb package clashes with newtxmath, which results in errors related to redefined commands. For example,

    LaTeX Error: Command `\Bbbk' already defined

This change guards the loading of the amssymb package so it is not used if newtxmath has already been loaded.