### PR TITLE
promotion: Display references for supplements

### DIFF
--- a/promotion/template/application.tex
+++ b/promotion/template/application.tex
@@ -1,5 +1,6 @@
 \documentclass[11pt,openany,oneside]{book}
 
+\usepackage{bibentry}
 \usepackage{glossaries}
 \usepackage{hyperref}
 \usepackage{pdfpages}
@@ -7,6 +8,11 @@
 
 \usepackage{application}
 
+
+% bibentry
+\AtBeginDocument{
+  \nobibliography*
+}
 
 % glossaries
 \loadglsentries{acronyms}


### PR DESCRIPTION
This change includes the bibentry (LaTeX) package in the template for academic promotion packages so that references in the supplementary material are displayed correctly.