### PR TITLE
promotion: Reorganize academic promotion template

### DIFF
--- a/promotion/template/application.tex
+++ b/promotion/template/application.tex
@@ -98,19 +98,6 @@ I believe no special accounting of emphasis is necessary, and there are no omiss
 \chapter{Commitment to Sustained Professional Development}  %------------------
 \input{statements/professional-development}
 
-%------------------------------------------------------------------------------
-\chapter{Supplementary Materials}  %-------------------------------------------
-
-\begin{supplements}[
-    directory=./supplements/teaching/,
-    section=section,
-    type=\LaTeXe{} packages,
-]
-  \supplement[
-      tocentry={The graded-review package},
-  ]{graded-review.pdf}{The \textsf{graded-review} package}
-\end{supplements}
-
 
 %------------------------------------------------------------------------------
 %------------------------------------------------------------------------------
@@ -127,20 +114,6 @@ Prior publications and presentations are listed in my curriculum vitae (Section~
 
 \input{records/scholarship}
 
-%------------------------------------------------------------------------------
-\chapter{Supplementary Materials}  %-------------------------------------------
-
-\begin{supplements}[
-    directory=supplements/scholarship/,
-    section=section,
-    structure=enumerate,
-    type=publications,
-]
-  \supplement[
-      tocentry={Building a Pathway for Student Learning: A How-To Guide to Course Design},
-  ]{jones2014building.pdf}{\bibentry{jones2014building}}
-\end{supplements}
-
 
 %------------------------------------------------------------------------------
 %------------------------------------------------------------------------------
@@ -153,8 +126,40 @@ Prior academic service is listed in my curriculum vitae (Section~\ref{section:cv
 
 \input{records/service}
 
+
 %------------------------------------------------------------------------------
-\chapter{Supplementary Materials}  %-------------------------------------------
+%------------------------------------------------------------------------------
+\part{Supplementary Material}  %-----------------------------------------------
+
+%------------------------------------------------------------------------------
+\chapter{Teaching}  %----------------------------------------------------------
+
+\begin{supplements}[
+    directory=./supplements/teaching/,
+    section=section,
+    type=\LaTeXe{} packages,
+]
+  \supplement[
+      tocentry={The graded-review package},
+  ]{graded-review.pdf}{The \textsf{graded-review} package}
+\end{supplements}
+
+%------------------------------------------------------------------------------
+\chapter{Scholarship}  %-------------------------------------------------------
+
+\begin{supplements}[
+    directory=supplements/scholarship/,
+    section=section,
+    structure=enumerate,
+    type=publications,
+]
+  \supplement[
+      tocentry={Building a Pathway for Student Learning: A How-To Guide to Course Design},
+  ]{jones2014building.pdf}{\bibentry{jones2014building}}
+\end{supplements}
+
+%------------------------------------------------------------------------------
+\chapter{Service}  %-----------------------------------------------------------
 
 \begin{supplements}[
     directory=./supplements/service/,


### PR DESCRIPTION
This change reorganizes the template for academic promotion packages, moving the supplementary material to the end of the package (Part V) rather than interspersing it throughout the package.

The new organization explicitly differs from that implied by the "Academic Promotion Package Checklist" in the "Instructions for Applying for Academic Promotion to Associate and Full Professor" provided by the Faculty Personnel Council (FPC), yet this change has been implicitly endorsed by feedback on various academic promotion packages over the past few years.