### PR TITLE
Use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,8 @@ jobs:
       - name: make
         run: make
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        if: ${{ matrix.os == 'debian:bullseye' }}
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: |


### PR DESCRIPTION
actions/upload-artifact@v2 was deprecated on 30 June 2024, and the GitHub Actions workflow using it is failing with the following error message:

    This request has been automatically failed because it uses a
    deprecated version of actions/upload-artifact: v2

Thus, this change updates the version of actions/upload-artifact.

A breaking change for upload-artifact@v4 is attempting to upload an artifact with the same name multiple times. This change avoids that issue by only storing artifacts for Debian Bullseye.

@actions/upload-artifact: https://github.com/actions/upload-artifact

(cherry picked from commit joel-coffman/latex-incubator@24c8a98376743a1d8a77aaaaa6cb6b765f33c1d5)